### PR TITLE
Removed the Tor bandwidth files (prevented containers from being run)

### DIFF
--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -7,8 +7,6 @@ services:
     ports:
       - "8080:8080"
     command: ["./docker/wait-for-it.sh", "mongodb:27017", "--", "npm", "run", "serve:ssr"]  
-    volumes:
-      - "/home/nick/Documents/website-backup/bandwidth:/home/nick/bandwidth"
 
   mongodb:
     image: "mongo"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,8 +7,6 @@ services:
     ports:
       - "127.0.0.1:8080:8080"
     command: ["./docker/wait-for-it.sh", "mongodb:27017", "--", "npm", "run", "serve:ssr"]  
-    volumes:
-      - "/home/nick/bandwidth:/home/nick/bandwidth"
 
   mongodb:
     image: "mongo"


### PR DESCRIPTION
This web server no longer has a Tor middle relay. As a result, we have no need for a bandwidth check.