### PR TITLE
Load Particles.js locally

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -14,7 +14,7 @@
     <app-root></app-root><br>
     <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha256-pasqAKBDmFT4eHoN2ndd6lN370kFiGUFyTiUHWhU7k8=" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js"></script>
+    <script src="/files/particles.min.js"></script>
     <script src="/files/particles/load_particles.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Found out that Ublock Origin will block the CDN used for Particles.js. That's a problem! This is the alternative